### PR TITLE
fix: required azurerm version for identities

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.59.0"
+      version = ">= 2.63.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
For versions of azurerm prior 2.63.0 the module initialization fails with the following error:

```
Error: Unsupported argument

   on .terraform/modules/storage_account/main.tf line 49, in resource "azurerm_storage_account" "storeacc":
   49:     identity_ids = var.identity_ids

 An argument named "identity_ids" is not expected here.
```

Azurerm [CHANGELOG](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/CHANGELOG-v2.md#2630-june-11-2021)