### PR TITLE
Add proper variable types

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,9 +56,9 @@ resource "azurerm_storage_account" "storeacc" {
     container_delete_retention_policy {
       days = var.container_soft_delete_retention_days
     }
-    versioning_enabled = var.enable_versioning
+    versioning_enabled       = var.enable_versioning
     last_access_time_enabled = var.last_access_time_enabled
-    change_feed_enabled = var.change_feed_enabled
+    change_feed_enabled      = var.change_feed_enabled
   }
 
   dynamic "network_rules" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,71 +1,85 @@
 variable "create_resource_group" {
   description = "Whether to create resource group and use it for all networking resources"
   default     = false
+  type        = bool
 }
 
 variable "resource_group_name" {
   description = "A container that holds related resources for an Azure solution"
   default     = "rg-demo-westeurope-01"
+  type        = string
 }
 
 variable "location" {
   description = "The location/region to keep all your network resources. To get the list of all locations with table format from azure cli, run 'az account list-locations -o table'"
   default     = "westeurope"
+  type        = string
 }
 
 variable "storage_account_name" {
   description = "The name of the azure storage account"
   default     = ""
+  type        = string
 }
 
 variable "account_kind" {
   description = "The type of storage account. Valid options are BlobStorage, BlockBlobStorage, FileStorage, Storage and StorageV2."
   default     = "StorageV2"
+  type        = string
 }
 
 variable "skuname" {
   description = "The SKUs supported by Microsoft Azure Storage. Valid options are Premium_LRS, Premium_ZRS, Standard_GRS, Standard_GZRS, Standard_LRS, Standard_RAGRS, Standard_RAGZRS, Standard_ZRS"
   default     = "Standard_RAGRS"
+  type        = string
 }
 
 variable "access_tier" {
   description = "Defines the access tier for BlobStorage and StorageV2 accounts. Valid options are Hot and Cool."
   default     = "Hot"
+  type        = string
 }
 
 variable "min_tls_version" {
   description = "The minimum supported TLS version for the storage account"
   default     = "TLS1_2"
+  type        = string
 }
 
 variable "blob_soft_delete_retention_days" {
   description = "Specifies the number of days that the blob should be retained, between `1` and `365` days. Defaults to `7`"
   default     = 7
+  type        = number
 }
 
 variable "container_soft_delete_retention_days" {
   description = "Specifies the number of days that the blob should be retained, between `1` and `365` days. Defaults to `7`"
   default     = 7
+  type        = number
 }
 
 variable "enable_versioning" {
   description = "Is versioning enabled? Default to `false`"
   default     = false
+  type        = bool
 }
 
 variable "last_access_time_enabled" {
   description = "Is the last access time based tracking enabled? Default to `false`"
   default     = false
+  type        = bool
 }
 
 variable "change_feed_enabled" {
   description = "Is the blob service properties for change feed events enabled?"
   default     = false
+  type        = bool
 }
 
 variable "enable_advanced_threat_protection" {
   description = "Boolean flag which controls if advanced threat protection is enabled."
   default     = false
+  type        = bool
 }
 
 variable "network_rules" {
@@ -106,6 +120,7 @@ variable "lifecycles" {
 variable "identity_ids" {
   description = "Specifies a list of user managed identity ids to be assigned. This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`"
   default     = null
+  type        = list(string)
 }
 
 variable "tags" {


### PR DESCRIPTION
This simply adds proper variable types for all variables, which is a requirement in newer versions of Terraform for booleans to work correctly.