### PR TITLE
Feat/storage account primary blob endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Name | Description
 `storage_account_id`|The ID of the storage account
 `sorage_account_name`|The name of the storage account
 `storage_account_primary_location`|The primary location of the storage account
+`storage_account_primary_blob_endpoint`|The endpoint URL for blob storage in the primary location
 `storage_account_primary_web_endpoint`|The endpoint URL for web storage in the primary location
 `storage_account_primary_web_host`|The hostname with port if applicable for web storage in the primary location
 `storage_primary_connection_string`|The primary connection string for the storage account

--- a/examples/complete/output.tf
+++ b/examples/complete/output.tf
@@ -28,6 +28,11 @@ output "storage_account_primary_location" {
   value       = module.storage.storage_account_primary_location
 }
 
+output "storage_account_primary_blob_endpoint" {
+  description = "The endpoint URL for blob storage in the primary location."
+  value       = module.storage.storage_account_primary_blob_endpoint
+}
+
 output "storage_account_primary_web_endpoint" {
   description = "The endpoint URL for web storage in the primary location."
   value       = module.storage.storage_account_primary_web_endpoint

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,6 @@ resource "azurerm_storage_account" "storeacc" {
   account_replication_type  = local.account_replication_type
   enable_https_traffic_only = true
   min_tls_version           = var.min_tls_version
-  allow_blob_public_access  = var.enable_advanced_threat_protection == true ? true : false
   tags                      = merge({ "ResourceName" = substr(format("sta%s%s", lower(replace(var.storage_account_name, "/[[:^alnum:]]/", "")), random_string.unique.result), 0, 24) }, var.tags, )
 
   identity {

--- a/output.tf
+++ b/output.tf
@@ -28,6 +28,11 @@ output "storage_account_primary_location" {
   value       = azurerm_storage_account.storeacc.primary_location
 }
 
+output "storage_account_primary_blob_endpoint" {
+  description = "The endpoint URL for blob storage in the primary location."
+  value       = azurerm_storage_account.storeacc.primary_blob_endpoint
+}
+
 output "storage_account_primary_web_endpoint" {
   description = "The endpoint URL for web storage in the primary location."
   value       = azurerm_storage_account.storeacc.primary_web_endpoint


### PR DESCRIPTION
This PR adds a new output `storage_account_primary_blob_endpoint` to set the `diag_storage_uri` attribute on a virtual_machine resource.

In addition, it solves issue #16 